### PR TITLE
Add polling capability.

### DIFF
--- a/devicetypes/tgsoverly/air-scape-whf.src/air-scape-whf.groovy
+++ b/devicetypes/tgsoverly/air-scape-whf.src/air-scape-whf.groovy
@@ -20,6 +20,7 @@ preferences {
 metadata {
     definition (name:"Air Scape WHF", namespace:"tgsoverly", author:"timothy@overly.me") {
         capability "Refresh"
+        capability "Polling"
 
         capability "Switch"
         capability "Switch Level"
@@ -126,6 +127,11 @@ def refresh(){
   setDeviceNetworkId()
 
 	return getSendCodeAction()
+}
+
+def poll() {
+  log.debug("airscape: polling status")
+  return getSendCodeAction()
 }
 
 def maximum(){


### PR DESCRIPTION
Without the polling capability, the temperature sensors are only updated when manually hitting the refresh button in SmartThings.